### PR TITLE
Feat/26 tools integration

### DIFF
--- a/canar/app/bot_tools/base.py
+++ b/canar/app/bot_tools/base.py
@@ -1,0 +1,29 @@
+from abc import ABC, abstractmethod
+from typing import Any
+from canar.app.bot_tools.models import ToolDefinition, ToolResult
+
+
+class BaseToolProvider(ABC):
+    """
+    Interface abstraite pour tous les fournisseurs d'outils de CanaR.
+    Définition générique et indépendante de MCP, OpenAI et Streamlit.
+    """
+    provider_id: str
+
+    async def initialize(self) -> None:
+        """Prépare le provider si nécessaire (connexion réseau, etc.)."""
+        pass
+
+    @abstractmethod
+    async def list_tools(self) -> list[ToolDefinition]:
+        """Retourne la liste des outils disponibles sous forme de ToolDefinition."""
+        pass
+
+    @abstractmethod
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> ToolResult:
+        """Exécute l'outil demandé et retourne un résultat normalisé ToolResult."""
+        pass
+
+    async def close(self) -> None:
+        """Ferme proprement les connexions réseau ou sessions (no-op par défaut)."""
+        pass

--- a/canar/app/bot_tools/base.py
+++ b/canar/app/bot_tools/base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Any
+
 from canar.app.bot_tools.models import ToolDefinition, ToolResult
 
 
@@ -8,9 +9,10 @@ class BaseToolProvider(ABC):
     Interface abstraite pour tous les fournisseurs d'outils de CanaR.
     Définition générique et indépendante de MCP, OpenAI et Streamlit.
     """
+
     provider_id: str
 
-    async def initialize(self) -> None:
+    async def initialize(self) -> None:  # noqa: B027
         """Prépare le provider si nécessaire (connexion réseau, etc.)."""
         pass
 
@@ -24,6 +26,6 @@ class BaseToolProvider(ABC):
         """Exécute l'outil demandé et retourne un résultat normalisé ToolResult."""
         pass
 
-    async def close(self) -> None:
+    async def close(self) -> None:  # noqa: B027
         """Ferme proprement les connexions réseau ou sessions (no-op par défaut)."""
         pass

--- a/canar/app/bot_tools/echo_provider.py
+++ b/canar/app/bot_tools/echo_provider.py
@@ -1,0 +1,61 @@
+from typing import Any
+from canar.app.bot_tools.base import BaseToolProvider
+from canar.app.bot_tools.errors import InvalidToolArguments, ToolNotFound
+from canar.app.bot_tools.models import ToolDefinition, ToolResult
+
+
+class EchoToolProvider(BaseToolProvider):
+    """
+    Provider factice pour tester et valider la chaîne de traitement des outils
+    sans aucune dépendance réseau, MCP ou LLM.
+    """
+
+    def __init__(self, provider_id: str = "echo"):
+        if "__" in provider_id:
+            raise ValueError("Le 'provider_id' ne doit pas contenir le séparateur '__'")
+        self.provider_id = provider_id
+
+    async def list_tools(self) -> list[ToolDefinition]:
+        return [
+            ToolDefinition(
+                provider_id=self.provider_id,
+                name="echo",
+                description="Répète le texte fourni en entrée. Utilisé pour les tests et diagnostics.",
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "text": {
+                            "type": "string",
+                            "description": "Le texte à répéter",
+                        }
+                    },
+                    "required": ["text"],
+                },
+            )
+        ]
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> ToolResult:
+        # Nettoyage du préfixe éventuel s'il est fourni (ex: "echo__echo" -> "echo")
+        actual_name = name.replace(f"{self.provider_id}__", "")
+
+        if actual_name != "echo":
+            raise ToolNotFound(tool_name=name, provider_id=self.provider_id)
+
+        # Validation stricte des arguments
+        if "text" not in arguments:
+            raise InvalidToolArguments(
+                tool_name=name, reason="L'argument requis 'text' est absent."
+            )
+
+        text_val = arguments["text"]
+        if not isinstance(text_val, str):
+            raise InvalidToolArguments(
+                tool_name=name,
+                reason=f"L'argument 'text' doit être une chaîne (reçu: {type(text_val).__name__}).",
+            )
+
+        return ToolResult(
+            content=f"Echo: {text_val}",
+            structured_content={"echo": text_val},
+            is_error=False,
+        )

--- a/canar/app/bot_tools/echo_provider.py
+++ b/canar/app/bot_tools/echo_provider.py
@@ -1,4 +1,5 @@
 from typing import Any
+
 from canar.app.bot_tools.base import BaseToolProvider
 from canar.app.bot_tools.errors import InvalidToolArguments, ToolNotFound
 from canar.app.bot_tools.models import ToolDefinition, ToolResult
@@ -20,7 +21,9 @@ class EchoToolProvider(BaseToolProvider):
             ToolDefinition(
                 provider_id=self.provider_id,
                 name="echo",
-                description="Répète le texte fourni en entrée. Utilisé pour les tests et diagnostics.",
+                description=(
+                    "Répète le texte fourni en entrée. Utilisé pour les tests et diagnostics."
+                ),
                 input_schema={
                     "type": "object",
                     "properties": {

--- a/canar/app/bot_tools/errors.py
+++ b/canar/app/bot_tools/errors.py
@@ -2,6 +2,7 @@ class ToolError(Exception):
     """
     Classe de base pour toutes les exceptions liées au domaine des outils CanaR.
     """
+
     pass
 
 
@@ -9,6 +10,7 @@ class ProviderUnavailable(ToolError):
     """
     Levée lorsqu'un fournisseur d'outils (ex: serveur MCP) est indisponible ou injoignable.
     """
+
     def __init__(self, provider_id: str, reason: str = ""):
         self.provider_id = provider_id
         self.reason = reason
@@ -22,6 +24,7 @@ class ToolNotFound(ToolError):
     """
     Levée lorsqu'un outil demandé est introuvable chez le provider ou dans le registre.
     """
+
     def __init__(self, tool_name: str, provider_id: str | None = None):
         self.tool_name = tool_name
         self.provider_id = provider_id
@@ -36,6 +39,7 @@ class InvalidToolArguments(ToolError):
     """
     Levée lorsque les arguments fournis par le LLM ne respectent pas le schéma de l'outil.
     """
+
     def __init__(self, tool_name: str, reason: str):
         self.tool_name = tool_name
         self.reason = reason
@@ -46,6 +50,7 @@ class ToolExecutionError(ToolError):
     """
     Levée lorsqu'une erreur inattendue survient pendant l'exécution d'un outil.
     """
+
     def __init__(self, tool_name: str, original_error: Exception | str):
         self.tool_name = tool_name
         self.original_error = original_error

--- a/canar/app/bot_tools/errors.py
+++ b/canar/app/bot_tools/errors.py
@@ -1,0 +1,52 @@
+class ToolError(Exception):
+    """
+    Classe de base pour toutes les exceptions liées au domaine des outils CanaR.
+    """
+    pass
+
+
+class ProviderUnavailable(ToolError):
+    """
+    Levée lorsqu'un fournisseur d'outils (ex: serveur MCP) est indisponible ou injoignable.
+    """
+    def __init__(self, provider_id: str, reason: str = ""):
+        self.provider_id = provider_id
+        self.reason = reason
+        msg = f"Le provider d'outils '{provider_id}' est indisponible"
+        if reason:
+            msg += f" : {reason}"
+        super().__init__(msg)
+
+
+class ToolNotFound(ToolError):
+    """
+    Levée lorsqu'un outil demandé est introuvable chez le provider ou dans le registre.
+    """
+    def __init__(self, tool_name: str, provider_id: str | None = None):
+        self.tool_name = tool_name
+        self.provider_id = provider_id
+        if provider_id:
+            msg = f"L'outil '{tool_name}' est introuvable sur le provider '{provider_id}'."
+        else:
+            msg = f"L'outil '{tool_name}' est introuvable."
+        super().__init__(msg)
+
+
+class InvalidToolArguments(ToolError):
+    """
+    Levée lorsque les arguments fournis par le LLM ne respectent pas le schéma de l'outil.
+    """
+    def __init__(self, tool_name: str, reason: str):
+        self.tool_name = tool_name
+        self.reason = reason
+        super().__init__(f"Arguments invalides pour l'outil '{tool_name}' : {reason}")
+
+
+class ToolExecutionError(ToolError):
+    """
+    Levée lorsqu'une erreur inattendue survient pendant l'exécution d'un outil.
+    """
+    def __init__(self, tool_name: str, original_error: Exception | str):
+        self.tool_name = tool_name
+        self.original_error = original_error
+        super().__init__(f"Erreur d'exécution de l'outil '{tool_name}' : {original_error}")

--- a/canar/app/bot_tools/local_provider.py
+++ b/canar/app/bot_tools/local_provider.py
@@ -1,0 +1,79 @@
+import logging
+from typing import Any
+
+from canar.app.bot_tools.base import BaseToolProvider
+from canar.app.bot_tools.errors import InvalidToolArguments, ToolNotFound
+from canar.app.bot_tools.models import ToolDefinition, ToolResult
+
+logger = logging.getLogger("LocalProvider")
+
+
+class LocalPythonProvider(BaseToolProvider):
+    def __init__(self, provider_id: str = "local"):
+        self.provider_id = provider_id
+
+    async def initialize(self):
+        logger.info("LocalPythonProvider initialisé")
+
+    async def list_tools(self) -> list[ToolDefinition]:
+        return [
+            ToolDefinition(
+                provider_id=self.provider_id,
+                name="web_search",
+                description=(
+                    "Effectue une recherche sur internet pour trouver des informations "
+                    "récentes. À utiliser quand tu as besoin de vérifier une actualité "
+                    "ou une documentation publique."
+                ),
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": (
+                                "Les mots clés de la recherche (ex: 'Taux chômage France 2025')"
+                            ),
+                        }
+                    },
+                    "required": ["query"],
+                },
+            )
+        ]
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> ToolResult:
+        actual_name = name.replace(f"{self.provider_id}__", "")
+
+        if actual_name == "web_search":
+            query = arguments.get("query", "")
+            if not query or not isinstance(query, str):
+                raise InvalidToolArguments(
+                    tool_name=name, reason="L'argument 'query' est requis et doit être une chaîne."
+                )
+            content = await self._do_web_search(query=query)
+            return ToolResult(content=content, is_error=False)
+
+        raise ToolNotFound(tool_name=name, provider_id=self.provider_id)
+
+    async def _do_web_search(self, query: str) -> str:
+        """Logique interne de l'outil web search"""
+        logger.info(f"Recherche web lancée pour : {query}")
+
+        try:
+            from ddgs import DDGS
+
+            result = DDGS().text(query, max_results=3)
+            if not result:
+                return f"Aucun résultat sur le web pour {query}."
+
+            formated_results = []
+            for r in result:
+                formated_results.append(
+                    f"Titre : {r['title']}\nLien : {r['href']}\nExtrait : {r['body']}"
+                )
+
+            return "\n\n---\n\n".join(formated_results)
+        except Exception as e:
+            return f"Erreur lors de la recherche web : {str(e)}"
+
+    async def close(self):
+        pass

--- a/canar/app/bot_tools/mcp_provider.py
+++ b/canar/app/bot_tools/mcp_provider.py
@@ -1,0 +1,64 @@
+import logging
+from typing import Any
+
+from mcp.client.session import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+
+from canar.app.bot_tools.base import BaseToolProvider
+from canar.app.bot_tools.models import ToolDefinition, ToolResult
+
+logger = logging.getLogger("MCPProvider")
+
+
+class MCPProvider(BaseToolProvider):
+    def __init__(self, provider_id: str, server_url: str):
+        self.provider_id = provider_id
+        self.server_url = server_url
+        self.session = None
+        self._client_context = None
+
+    async def initialize(self):
+        logger.info(f"Connexion au MCP {self.provider_id} ({self.server_url})...")
+        self._client_context = streamable_http_client(self.server_url)
+        read_stream, write_stream = await self._client_context.__aenter__()
+
+        self.session = ClientSession(read_stream, write_stream)
+        await self.session.__aenter__()
+        await self.session.initialize()
+
+    async def list_tools(self) -> list[ToolDefinition]:
+        if not self.session:
+            logger.warning(
+                f"Le provider MCP '{self.provider_id}' n'est pas connecté. Outils ignorés."
+            )
+            return []
+
+        response = await self.session.list_tools()
+        definitions = []
+
+        for tool in response.tools:
+            definitions.append(
+                ToolDefinition(
+                    provider_id=self.provider_id,
+                    name=tool.name,
+                    description=tool.description or "",
+                    input_schema=tool.input_schema or {},
+                )
+            )
+
+        return definitions
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> ToolResult:
+        actual_name = name.replace(f"{self.provider_id}__", "")
+
+        result = await self.session.call_tool(actual_name, arguments=arguments)
+        extracted_text = [c.text for c in result if c.type == "text"]
+        content = "\n".join(extracted_text)
+
+        return ToolResult(content=content, is_error=False)
+
+    async def close(self):
+        if self.session:
+            await self.session.__aexit__(None, None, None)
+        if self._client_context:
+            await self._client_context.__aexit__(None, None, None)

--- a/canar/app/bot_tools/models.py
+++ b/canar/app/bot_tools/models.py
@@ -1,0 +1,32 @@
+from typing import Any
+from pydantic import BaseModel, Field
+
+
+class ToolDefinition(BaseModel):
+    """
+    Définition agnostique d'un outil disponible.
+    """
+    provider_id: str
+    name: str
+    description: str = ""
+    input_schema: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolCall(BaseModel):
+    """
+    Représentation d'une demande d'exécution d'outil par un modèle ou un utilisateur.
+    """
+    call_id: str
+    full_name: str  # ex. "datagouv__search" ou "echo__echo"
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolResult(BaseModel):
+    """
+    Résultat normalisé d'un appel d'outil.
+    """
+    call_id: str | None = None
+    content: str
+    structured_content: dict[str, Any] | list[Any] | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    is_error: bool = False

--- a/canar/app/bot_tools/models.py
+++ b/canar/app/bot_tools/models.py
@@ -1,4 +1,5 @@
 from typing import Any
+
 from pydantic import BaseModel, Field
 
 
@@ -6,6 +7,7 @@ class ToolDefinition(BaseModel):
     """
     Définition agnostique d'un outil disponible.
     """
+
     provider_id: str
     name: str
     description: str = ""
@@ -16,6 +18,7 @@ class ToolCall(BaseModel):
     """
     Représentation d'une demande d'exécution d'outil par un modèle ou un utilisateur.
     """
+
     call_id: str
     full_name: str  # ex. "datagouv__search" ou "echo__echo"
     arguments: dict[str, Any] = Field(default_factory=dict)
@@ -25,6 +28,7 @@ class ToolResult(BaseModel):
     """
     Résultat normalisé d'un appel d'outil.
     """
+
     call_id: str | None = None
     content: str
     structured_content: dict[str, Any] | list[Any] | None = None

--- a/canar/app/bot_tools/registry.py
+++ b/canar/app/bot_tools/registry.py
@@ -1,0 +1,98 @@
+import logging
+from typing import Any
+
+from canar.app.bot_tools.base import BaseToolProvider
+from canar.app.bot_tools.errors import (
+    ProviderUnavailable,
+    ToolExecutionError,
+    ToolNotFound,
+)
+from canar.app.bot_tools.models import ToolDefinition, ToolResult
+
+logger = logging.getLogger("ToolRegistry")
+
+
+class ToolRegistry:
+    """
+    Registre central gérant l'enregistrement des providers, la découverte des outils
+    et le routage des appels vers le bon provider.
+    """
+
+    def __init__(self):
+        self._providers: dict[str, BaseToolProvider] = {}
+
+    def register_provider(self, provider_id: str, provider: BaseToolProvider) -> None:
+        """Enregistre un fournisseur d'outils au registre."""
+        if "__" in provider_id:
+            raise ValueError(f"L'identifiant de provider '{provider_id}' ne doit pas contenir '__'.")
+
+        self._providers[provider_id] = provider
+        logger.info(f"Provider '{provider_id}' enregistré dans le registre.")
+
+    async def initialize_all(self) -> None:
+        """Initialise tous les providers enregistrés."""
+        for pid, provider in self._providers.items():
+            try:
+                await provider.initialize()
+                logger.info(f"Provider '{pid}' initialisé avec succès.")
+            except Exception as e:
+                logger.error(f"Échec de l'initialisation du provider '{pid}' : {e}")
+
+    async def list_all_tools(self, allowed_providers: list[str] | None = None) -> list[ToolDefinition]:
+        """
+        Récupère la liste de tous les ToolDefinition enregistrés (filtrés optionnellement par provider).
+        Applique la convention de nommage public : provider_id__tool_name.
+        """
+        all_definitions: list[ToolDefinition] = []
+
+        for pid, provider in self._providers.items():
+            if allowed_providers is not None and pid not in allowed_providers:
+                continue
+
+            try:
+                raw_tools = await provider.list_tools()
+                for tool in raw_tools:
+                    # Garantir que le nom exposé est bien préfixé par provider_id__
+                    full_name = tool.name if tool.name.startswith(f"{pid}__") else f"{pid}__{tool.name}"
+                    prefixed_tool = ToolDefinition(
+                        provider_id=pid,
+                        name=full_name,
+                        description=tool.description,
+                        input_schema=tool.input_schema,
+                    )
+                    all_definitions.append(prefixed_tool)
+            except Exception as e:
+                logger.error(f"Erreur lors de la récupération des outils du provider '{pid}' : {e}")
+
+        return all_definitions
+
+    async def execute_tool(self, tool_name: str, arguments: dict[str, Any], call_id: str | None = None) -> ToolResult:
+        """
+        Route un appel d'outil (format provider_id__tool_name) vers le bon provider.
+        """
+        if "__" not in tool_name:
+            raise ToolNotFound(tool_name=tool_name)
+
+        provider_id, original_tool_name = tool_name.split("__", 1)
+
+        provider = self._providers.get(provider_id)
+        if not provider:
+            raise ProviderUnavailable(provider_id=provider_id, reason="Provider non trouvé dans le registre.")
+
+        try:
+            logger.info(f"Routage de '{tool_name}' vers le provider '{provider_id}'.")
+            result = await provider.call_tool(original_tool_name, arguments)
+            result.call_id = call_id
+            return result
+        except (ToolNotFound, ProviderUnavailable, Exception) as e:
+            if not isinstance(e, (ToolNotFound, ProviderUnavailable)):
+                raise ToolExecutionError(tool_name=tool_name, original_error=e) from e
+            raise
+
+    async def cleanup_all(self) -> None:
+        """Ferme tous les providers enregistrés."""
+        for pid, provider in self._providers.items():
+            try:
+                await provider.close()
+            except Exception as e:
+                logger.error(f"Erreur lors de la fermeture du provider '{pid}' : {e}")

--- a/canar/app/bot_tools/registry.py
+++ b/canar/app/bot_tools/registry.py
@@ -24,7 +24,9 @@ class ToolRegistry:
     def register_provider(self, provider_id: str, provider: BaseToolProvider) -> None:
         """Enregistre un fournisseur d'outils au registre."""
         if "__" in provider_id:
-            raise ValueError(f"L'identifiant de provider '{provider_id}' ne doit pas contenir '__'.")
+            raise ValueError(
+                f"L'identifiant de provider '{provider_id}' ne doit pas contenir '__'."
+            )
 
         self._providers[provider_id] = provider
         logger.info(f"Provider '{provider_id}' enregistré dans le registre.")
@@ -38,9 +40,12 @@ class ToolRegistry:
             except Exception as e:
                 logger.error(f"Échec de l'initialisation du provider '{pid}' : {e}")
 
-    async def list_all_tools(self, allowed_providers: list[str] | None = None) -> list[ToolDefinition]:
+    async def list_all_tools(
+        self, allowed_providers: list[str] | None = None
+    ) -> list[ToolDefinition]:
         """
-        Récupère la liste de tous les ToolDefinition enregistrés (filtrés optionnellement par provider).
+        Récupère la liste de tous les ToolDefinition enregistrés
+        (filtrés optionnellement par provider).
         Applique la convention de nommage public : provider_id__tool_name.
         """
         all_definitions: list[ToolDefinition] = []
@@ -53,7 +58,9 @@ class ToolRegistry:
                 raw_tools = await provider.list_tools()
                 for tool in raw_tools:
                     # Garantir que le nom exposé est bien préfixé par provider_id__
-                    full_name = tool.name if tool.name.startswith(f"{pid}__") else f"{pid}__{tool.name}"
+                    full_name = (
+                        tool.name if tool.name.startswith(f"{pid}__") else f"{pid}__{tool.name}"
+                    )
                     prefixed_tool = ToolDefinition(
                         provider_id=pid,
                         name=full_name,
@@ -66,7 +73,9 @@ class ToolRegistry:
 
         return all_definitions
 
-    async def execute_tool(self, tool_name: str, arguments: dict[str, Any], call_id: str | None = None) -> ToolResult:
+    async def execute_tool(
+        self, tool_name: str, arguments: dict[str, Any], call_id: str | None = None
+    ) -> ToolResult:
         """
         Route un appel d'outil (format provider_id__tool_name) vers le bon provider.
         """
@@ -77,7 +86,9 @@ class ToolRegistry:
 
         provider = self._providers.get(provider_id)
         if not provider:
-            raise ProviderUnavailable(provider_id=provider_id, reason="Provider non trouvé dans le registre.")
+            raise ProviderUnavailable(
+                provider_id=provider_id, reason="Provider non trouvé dans le registre."
+            )
 
         try:
             logger.info(f"Routage de '{tool_name}' vers le provider '{provider_id}'.")

--- a/canar/app/bot_tools/tool_config.py
+++ b/canar/app/bot_tools/tool_config.py
@@ -1,0 +1,41 @@
+from pydantic import BaseModel, Field
+
+
+class MCPProviderConfig(BaseModel):
+    """Configuration d'un serveur distant MCP (Model Context Protocol)."""
+
+    url: str
+    transport: str = Field(default="streamable_http")
+    timeout_seconds: int = Field(default=15, ge=1)
+    read_timeout_seconds: int = Field(default=60, ge=1)
+    headers: dict[str, str] = Field(default_factory=dict)
+    description: str | None = None
+
+
+class LocalProviderConfig(BaseModel):
+    """Configuration d'un provider Python local."""
+
+    description: str | None = None
+
+
+class ToolProvidersConfig(BaseModel):
+    """
+    Section `tool_providers` sous-divisée par catégorie (mcp, local).
+    """
+
+    mcp: dict[str, MCPProviderConfig] = Field(default_factory=dict)
+    local: dict[str, LocalProviderConfig] = Field(default_factory=dict)
+
+    def has_provider(self, provider_id: str) -> bool:
+        """Vérifie si un provider existe dans l'une des sous-sections (mcp ou local)."""
+        return provider_id in self.mcp or provider_id in self.local
+
+    def get_provider(
+        self, provider_id: str
+    ) -> MCPProviderConfig | LocalProviderConfig | None:
+        """Retourne la configuration d'un provider par son identifiant."""
+        if provider_id in self.mcp:
+            return self.mcp[provider_id]
+        if provider_id in self.local:
+            return self.local[provider_id]
+        return None

--- a/canar/app/bot_tools/tool_config.py
+++ b/canar/app/bot_tools/tool_config.py
@@ -30,9 +30,7 @@ class ToolProvidersConfig(BaseModel):
         """Vérifie si un provider existe dans l'une des sous-sections (mcp ou local)."""
         return provider_id in self.mcp or provider_id in self.local
 
-    def get_provider(
-        self, provider_id: str
-    ) -> MCPProviderConfig | LocalProviderConfig | None:
+    def get_provider(self, provider_id: str) -> MCPProviderConfig | LocalProviderConfig | None:
         """Retourne la configuration d'un provider par son identifiant."""
         if provider_id in self.mcp:
             return self.mcp[provider_id]

--- a/canar/app/bot_tools/tools_config.exemple.yaml
+++ b/canar/app/bot_tools/tools_config.exemple.yaml
@@ -1,0 +1,18 @@
+# ==============================================================================
+# Fichier d'exemple de configuration des outils pour CanaR
+# Fichier : tools_config.exemple.yaml
+# ==============================================================================
+
+tool_providers:
+  mcp:
+    datagouv:
+      url: "https://mcp.data.gouv.fr/mcp"
+      transport: "streamable_http"
+      timeout_seconds: 15
+      read_timeout_seconds: 60
+      headers: {}
+      description: "Serveur MCP officiel de data.gouv.fr"
+
+  local:
+    local:
+      description: "Fournisseur d'outils Python locaux (ex: web_search)"

--- a/canar/app/bot_tools/tools_config.yaml
+++ b/canar/app/bot_tools/tools_config.yaml
@@ -1,0 +1,9 @@
+tool_providers:
+  mcp:
+    datagouv:
+      url: "https://mcp.data.gouv.fr/mcp"
+      timeout_seconds: 15
+      read_timeout_seconds: 60
+  local:
+    local:
+      description: "Outils Python locaux"

--- a/canar/app/chatbots/chatbot_config.py
+++ b/canar/app/chatbots/chatbot_config.py
@@ -5,6 +5,7 @@ from sqlmodel import Field, Session, SQLModel, select
 
 
 class ChatbotConfig(SQLModel, table=True):
+    
     # id avec des minuscules, chiffres et underscores uniquement
     id: str = Field(primary_key=True, regex=r"^[a-z0-9_]+$")
     # name et system_prompt ne peuvent pas être vides

--- a/canar/app/chatbots/chatbot_config.py
+++ b/canar/app/chatbots/chatbot_config.py
@@ -5,7 +5,6 @@ from sqlmodel import Field, Session, SQLModel, select
 
 
 class ChatbotConfig(SQLModel, table=True):
-    
     # id avec des minuscules, chiffres et underscores uniquement
     id: str = Field(primary_key=True, regex=r"^[a-z0-9_]+$")
     # name et system_prompt ne peuvent pas être vides

--- a/canar/app/chatbots/chatbot_config_file.py
+++ b/canar/app/chatbots/chatbot_config_file.py
@@ -5,6 +5,27 @@ from pydantic import BaseModel, Field, ValidationError
 logger = logging.getLogger("ChatbotConfigFile")
 
 
+class AllowedToolConfig(BaseModel):
+    """
+    Déclaration d'un provider autorisé pour un chatbot avec optionnellement
+    une liste explicite d'outils autorisés (allowlist).
+    """
+
+    provider: str
+    tools: list[str] = Field(default_factory=list)  # Si vide, tous les outils du provider sont autorisés
+
+
+class ToolPolicyConfig(BaseModel):
+    """
+    Politique et garde-fous d'exécution des outils pour un chatbot.
+    """
+
+    max_iterations: int = Field(default=4, ge=1)
+    max_calls_per_turn: int = Field(default=4, ge=1)
+    max_result_chars: int = Field(default=12000, ge=100)
+    total_timeout_seconds: int = Field(default=90, ge=1)
+
+
 class ChatbotYAMLConfig(BaseModel):
     # id avec des minuscules, chiffres et underscores uniquement
     id: str = Field(pattern=r"^[a-z0-9_]+$")
@@ -22,18 +43,31 @@ class ChatbotYAMLConfig(BaseModel):
     score_threshold: float = Field(default=0.35, ge=0.0, le=1.0)
     # max_context_tokens cohérent avec le slider
     max_context_tokens: int = Field(default=2048, ge=256)
-    allowed_tools: list[str] = Field(default_factory=list)
+
+    # Nouveaux champs d'outils et politiques du Ticket III-2
+    allowed_tools: list[AllowedToolConfig | str] = Field(default_factory=list)
+    tool_policy: ToolPolicyConfig = Field(default_factory=ToolPolicyConfig)
+
+    def get_allowed_provider_ids(self) -> list[str]:
+        """Retourne la liste simple de tous les identifiants de providers autorisés."""
+        provider_ids = []
+        for item in self.allowed_tools:
+            if isinstance(item, str):
+                provider_ids.append(item)
+            elif isinstance(item, AllowedToolConfig):
+                provider_ids.append(item.provider)
+        return provider_ids
 
     @classmethod
     def createChatbot(cls, yaml_data: dict) -> "ChatbotYAMLConfig":
         """
         Crée et retourne une instance d'objet ChatbotYAMLConfig à partir des données YAML.
-        La sauvegarde en base de données est géré séparément.
+        La sauvegarde en base de données est gérée séparément.
         """
         try:
             return cls.model_validate(yaml_data)
         except Exception as e:
-            raise ValueError(f"Erreur de synthaxe YAML pour le chatbot {e}") from e
+            raise ValueError(f"Erreur de syntaxe YAML pour le chatbot : {e}") from e
 
     @classmethod
     def checkChatbot(cls, yaml_data: dict) -> bool:

--- a/canar/app/chatbots/chatbot_config_file.py
+++ b/canar/app/chatbots/chatbot_config_file.py
@@ -12,7 +12,9 @@ class AllowedToolConfig(BaseModel):
     """
 
     provider: str
-    tools: list[str] = Field(default_factory=list)  # Si vide, tous les outils du provider sont autorisés
+    tools: list[str] = Field(
+        default_factory=list
+    )  # Si vide, tous les outils du provider sont autorisés
 
 
 class ToolPolicyConfig(BaseModel):

--- a/canar/app/chatbots/chatbotconfig.yaml
+++ b/canar/app/chatbots/chatbotconfig.yaml
@@ -5,7 +5,8 @@ chatbots:
     collections:
       - "utilitr_v1"
     accepted_file_types: []
-    model: "mistral-medium"
+    allowed_tools: []
+    model: "gpt-4o-mini"
     system_prompt: |
       Tu es “CoachR”, un formateur R très pédagogue pour un public venant majoritairement de SAS et peu familier des langages de programmation.
       Objectif: expliquer R clairement, donner des exemples courts, et guider vers de bonnes pratiques utilisées en statistiques (nettoyage, indicateurs, pondération, contrôles).
@@ -33,6 +34,7 @@ chatbots:
     collections: [] 
     accepted_file_types: ["sas"]
     export_extension: "R" 
+    allowed_tools: []
     system_prompt: |
       Tu es “TradSAS2R”, un assistant expert en SAS (data step, PROC SQL, PROC FREQ/MEANS/GLM/LOGISTIC/SURVEY*, formats, macro, libname) et en R (tidyverse, data.table, arrow, duckdb, survey, srvyr).
       Objectif: traduire du code SAS en R avec une fidélité maximale au comportement (résultats identiques à tolérance près), puis expliquer pédagogiquement.
@@ -56,4 +58,12 @@ chatbots:
 
       Sortie: Markdown, avec titres H2/H3, et blocs de code ```r```.
 
+      
+  - id: super_agent_eco
+    name: "Agent Économique"
+    description: "Agent économique pour poser des question datagouv"
+    collections: [] 
+    accepted_file_types: []
+    system_prompt: "Tu es un agent capable de faire des recherches et de lire des API..."
+    allowed_tools: ["local", "datagouv"]
     

--- a/canar/app/config_file.py
+++ b/canar/app/config_file.py
@@ -1,4 +1,5 @@
 import logging
+
 from pydantic import BaseModel, Field, model_validator
 
 from canar.app.bot_tools.tool_config import ToolProvidersConfig
@@ -30,8 +31,8 @@ class CanarConfigFile(BaseModel):
                     local_keys = list(self.tool_providers.local.keys())
                     available = mcp_keys + local_keys
                     raise ValueError(
-                        f"[Erreur de Configuration] Le chatbot '{bot.id}' fait référence au provider "
-                        f"inconnu '{provider_id}' dans ses 'allowed_tools'. "
+                        f"[Erreur de Configuration] Le chatbot '{bot.id}' fait référence au "
+                        f"provider inconnu '{provider_id}' dans ses 'allowed_tools'. "
                         f"Providers déclarés disponibles : {available}"
                     )
         return self

--- a/canar/app/config_file.py
+++ b/canar/app/config_file.py
@@ -1,0 +1,37 @@
+import logging
+from pydantic import BaseModel, Field, model_validator
+
+from canar.app.bot_tools.tool_config import ToolProvidersConfig
+from canar.app.chatbots.chatbot_config_file import ChatbotYAMLConfig
+
+logger = logging.getLogger("CanarConfigFile")
+
+
+class CanarConfigFile(BaseModel):
+    """
+    Modèle racine représentant l'intégralité d'un fichier de configuration CanaR.
+    Englobe les `tool_providers` et la liste des `chatbots`, et garantit la cohérence globale.
+    """
+
+    tool_providers: ToolProvidersConfig = Field(default_factory=ToolProvidersConfig)
+    chatbots: list[ChatbotYAMLConfig] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_cross_references(self) -> "CanarConfigFile":
+        """
+        Vérifie sans aucun accès réseau que tous les providers référencés dans
+        `allowed_tools` de chaque chatbot existent bien dans `tool_providers`.
+        """
+        for bot in self.chatbots:
+            allowed_providers = bot.get_allowed_provider_ids()
+            for provider_id in allowed_providers:
+                if not self.tool_providers.has_provider(provider_id):
+                    mcp_keys = list(self.tool_providers.mcp.keys())
+                    local_keys = list(self.tool_providers.local.keys())
+                    available = mcp_keys + local_keys
+                    raise ValueError(
+                        f"[Erreur de Configuration] Le chatbot '{bot.id}' fait référence au provider "
+                        f"inconnu '{provider_id}' dans ses 'allowed_tools'. "
+                        f"Providers déclarés disponibles : {available}"
+                    )
+        return self

--- a/canar/app/main.py
+++ b/canar/app/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import mimetypes
 import time
@@ -11,16 +12,15 @@ from sqlmodel import Session, select
 from canar.app.api.embed_client import EmbedClient
 from canar.app.api.llm_client import ChatClient
 from canar.app.api.retrieval import search_qdrant
-
 from canar.app.bot_tools.registry import ToolRegistry
+from canar.app.bot_tools.tool_config import ToolProvidersConfig
 from canar.app.chatbots.chatbot_config import ChatbotConfig
 from canar.app.config import AppConfig
 from canar.app.state import DB
 from canar.app.ui.chat import render_messages, stream_answer
 from canar.app.ui.sidebar import sidebar
 from canar.app.utils.llm_utils import assemble_context, build_universal_messages
-from canar.app.yaml_loader import load_chatbot_on_boot, load_bot_tools_on_boot
-import asyncio
+from canar.app.yaml_loader import load_bot_tools_on_boot, load_chatbot_on_boot
 
 st.set_page_config(page_title="CanaR", page_icon="🦆", layout="wide")
 
@@ -261,6 +261,7 @@ if current_bot and current_bot.accepted_file_types:
     if uploaded is not None:
         uploaded_file_content = uploaded.read().decode("utf-8", errors="ignore")
 
+
 async def process_agent_turn():
     print("Initialisation des connexions réseau...")
     await tool_registry.initialize_all()
@@ -273,9 +274,9 @@ async def process_agent_turn():
 
         if not allowed_tools or len(allowed_tools) == 0:
             gen = chat.stream_chat(messages, temperature=temperature, max_tokens=max_tokens)
-            answer = stream_answer(db, USER_ID, conv_id, gen)
+            stream_answer(db, USER_ID, conv_id, gen)
             return
-        
+
         is_final_answer = False
         final_text = ""
 
@@ -337,7 +338,7 @@ async def process_agent_turn():
                 time.sleep(0.01)
 
         gen = fake_stream_generator(final_text)
-        answer = stream_answer(db, USER_ID, conv_id, gen)
+        stream_answer(db, USER_ID, conv_id, gen)
     finally:
         print("Fermeture des connexions réseau...")
         await tool_registry.cleanup_all()
@@ -411,4 +412,3 @@ if current_bot.export_extension:
                 file_name=f"export.{current_bot.export_extension}",
                 mime=current_bot.exporte_mime_type,
             )
-

--- a/canar/app/main.py
+++ b/canar/app/main.py
@@ -12,14 +12,15 @@ from canar.app.api.embed_client import EmbedClient
 from canar.app.api.llm_client import ChatClient
 from canar.app.api.retrieval import search_qdrant
 
-# from canar.app.bot_tools.registry import ToolRegistry
+from canar.app.bot_tools.registry import ToolRegistry
 from canar.app.chatbots.chatbot_config import ChatbotConfig
 from canar.app.config import AppConfig
 from canar.app.state import DB
 from canar.app.ui.chat import render_messages, stream_answer
 from canar.app.ui.sidebar import sidebar
 from canar.app.utils.llm_utils import assemble_context, build_universal_messages
-from canar.app.yaml_loader import load_chatbot_on_boot
+from canar.app.yaml_loader import load_chatbot_on_boot, load_bot_tools_on_boot
+import asyncio
 
 st.set_page_config(page_title="CanaR", page_icon="🦆", layout="wide")
 
@@ -29,23 +30,24 @@ db = DB(cfg.db_path)
 
 
 @st.cache_resource()
-def init_app_agent_data(_db: DB):
+def init_tool_registry() -> tuple[ToolRegistry, ToolProvidersConfig]:
+    yaml_path = "canar/app/bot_tools/tools_config.yaml"
+    return load_bot_tools_on_boot(yaml_path)
+
+
+tool_registry, providers_config = init_tool_registry()
+
+
+@st.cache_resource()
+def init_app_agent_data(_db: DB, _providers_config: ToolProvidersConfig = None):
 
     mimetypes.add_type("text/x-r-source", ".r")
     mimetypes.add_type("application/x-sas", ".sas")
 
-    load_chatbot_on_boot(cfg.chatbot_config_path, _db)
+    load_chatbot_on_boot(cfg.chatbot_config_path, _db, _providers_config)
 
 
-# @st.cache_resource()
-# def init_tool_registry() -> ToolRegistry:
-#     yaml_path = "canar/app/bot_tools/tools_config.yaml"
-#     return load_bot_tools_on_boot(yaml_path)
-
-
-# tool_registry = init_tool_registry()
-
-init_app_agent_data(db)
+init_app_agent_data(db, providers_config)
 
 
 @st.cache_data(ttl=3600)
@@ -259,6 +261,88 @@ if current_bot and current_bot.accepted_file_types:
     if uploaded is not None:
         uploaded_file_content = uploaded.read().decode("utf-8", errors="ignore")
 
+async def process_agent_turn():
+    print("Initialisation des connexions réseau...")
+    await tool_registry.initialize_all()
+
+    try:
+        allowed_tools = current_bot.allowed_tools
+        print("avant le async")
+        allowed_tools_schemas = await tool_registry.get_all_tools_schemas(allowed_tools)
+        print("après le async")
+
+        if not allowed_tools or len(allowed_tools) == 0:
+            gen = chat.stream_chat(messages, temperature=temperature, max_tokens=max_tokens)
+            answer = stream_answer(db, USER_ID, conv_id, gen)
+            return
+        
+        is_final_answer = False
+        final_text = ""
+
+        MAX_ITERATIONS = 5
+        iteration_count = 0
+        print("avant le with")
+        with st.status("L'agent analyse la demande...", expanded=True) as status:
+            print("L'agent analyse la demande...")
+            while not is_final_answer and iteration_count < MAX_ITERATIONS:
+                iteration_count += 1
+                print(f"Itération {iteration_count}")
+
+                response = chat.sync_chat(
+                    messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    allowed_tools_schemas=allowed_tools_schemas,
+                )
+
+                llm_msg = response.choices[0].message
+
+                if llm_msg.tool_calls:
+                    messages.append(llm_msg.model_dump(exclude_none=True))
+                    for tool_call in llm_msg.tool_calls:
+                        tool_name = tool_call.function.name
+                        st.write(f"Appel à l'outil {tool_name}...")
+                        print(f"Appel à l'outil {tool_name}...")
+                        try:
+                            tool_args = json.loads(tool_call.function.arguments)
+                            print(f"Le LLM demande '{tool_name}' avec les arguments : {tool_args}")
+                            result = await tool_registry.execute_tool(tool_name, tool_args)
+                            st.write("Données récupérées avec succès")
+                            print(f"Réponse de l'outil (extrait) : {str(result)[:500]}...")
+                        except Exception as e:
+                            result = f"Erreur lors de l'exécution de l'outil {tool_name} : {str(e)}"
+                            st.write(f"Erreur : {result}")
+                        messages.append(
+                            {"role": "tool", "tool_call_id": tool_call.id, "content": str(result)}
+                        )
+
+                else:
+                    is_final_answer = True
+                    final_text = llm_msg.content
+                    status.update(label="Réponse générée", state="complete", expanded=False)
+
+            if not is_final_answer:
+                final_text = (
+                    "Désolé, j'ai dû interrompre mes recherches car elles prenaient "
+                    "trop de temps ou tournaient en boucle. "
+                    "Voici un résumé de ce que j'ai trouvé jusque-là..."
+                )
+                status.update(
+                    label="Recherche interrompue (Limite atteinte)", state="error", expanded=False
+                )
+
+        def fake_stream_generator(text):
+            for chunk in text.split(" "):
+                yield chunk + " "
+                time.sleep(0.01)
+
+        gen = fake_stream_generator(final_text)
+        answer = stream_answer(db, USER_ID, conv_id, gen)
+    finally:
+        print("Fermeture des connexions réseau...")
+        await tool_registry.cleanup_all()
+
+
 user_input = st.chat_input("Pose ta question (ou colle ton code)…")
 if user_input:
     # 1) show the user message immediately in the chat
@@ -298,72 +382,7 @@ if user_input:
         rag_context=context_text,
     )
 
-    allowed_tools = current_bot.allowed_tools
-
-    # allowed_tools_schemas = asyncio.run(tool_registry.get_all_tools_schemas(allowed_tools))
-
-    if not allowed_tools or len(allowed_tools) == 0:
-        gen = chat.stream_chat(messages, temperature=temperature, max_tokens=max_tokens)
-        answer = stream_answer(db, USER_ID, conv_id, gen)
-    else:
-        is_final_answer = False
-        final_text = ""
-
-        MAX_ITERATIONS = 5
-        iteration_count = 0
-
-        with st.status("L'agent analyse la demande...", expanded=True) as status:
-            while not is_final_answer and iteration_count < MAX_ITERATIONS:
-                iteration_count += 1
-
-                response = chat.sync_chat(
-                    messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    # allowed_tools_schemas=allowed_tools_schemas,
-                )
-
-                llm_msg = response.choices[0].message
-
-                if llm_msg.tool_calls:
-                    messages.append(llm_msg.model_dump(exclude_none=True))
-                    for tool_call in llm_msg.tool_calls:
-                        tool_name = tool_call.function.name
-                        st.write(f"Appel à l'outil {tool_name}...")
-                        try:
-                            tool_args = json.loads(tool_call.function.arguments)
-                            result = None
-                            # asyncio.run(tool_registry.execute_tool(tool_name, tool_args))
-                            st.write("Données récupérées avec succès")
-                        except Exception as e:
-                            result = f"Erreur lors de l'exécution de l'outil {tool_name} : {str(e)}"
-                            st.write(f"Erreur : {result}")
-                        messages.append(
-                            {"role": "tool", "tool_call_id": tool_call.id, "content": str(result)}
-                        )
-
-                else:
-                    is_final_answer = True
-                    final_text = llm_msg.content
-                    status.update(label="Réponse générée", state="complete", expanded=False)
-
-            if not is_final_answer:
-                final_text = (
-                    "Désolé, j'ai dû interrompre mes recherches car elles prenaient "
-                    "trop de temps ou tournaient en boucle. "
-                    "Voici un résumé de ce que j'ai trouvé jusque-là..."
-                )
-                status.update(
-                    label="Recherche interrompue (Limite atteinte)", state="error", expanded=False
-                )
-
-        def fake_stream_generator(text):
-            for chunk in text.split(" "):
-                yield chunk + " "
-                time.sleep(0.01)
-
-        gen = fake_stream_generator(final_text)
-        answer = stream_answer(db, USER_ID, conv_id, gen)
+    asyncio.run(process_agent_turn())
 
     # Citations panel
     if len(src_list):
@@ -392,3 +411,4 @@ if current_bot.export_extension:
                 file_name=f"export.{current_bot.export_extension}",
                 mime=current_bot.exporte_mime_type,
             )
+

--- a/canar/app/tests/test_tools_domain.py
+++ b/canar/app/tests/test_tools_domain.py
@@ -1,0 +1,88 @@
+import asyncio
+import pytest
+from canar.app.bot_tools.echo_provider import EchoToolProvider
+from canar.app.bot_tools.errors import (
+    InvalidToolArguments,
+    ProviderUnavailable,
+    ToolNotFound,
+)
+from canar.app.bot_tools.registry import ToolRegistry
+
+
+def test_echo_provider_list_tools():
+    provider = EchoToolProvider(provider_id="echo")
+    tools = asyncio.run(provider.list_tools())
+    assert len(tools) == 1
+    assert tools[0].name == "echo"
+    assert tools[0].provider_id == "echo"
+    assert "text" in tools[0].input_schema["properties"]
+
+
+def test_echo_provider_nominal_call():
+    provider = EchoToolProvider(provider_id="echo")
+    result = asyncio.run(provider.call_tool("echo", {"text": "Bonjour CanaR!"}))
+    assert result.is_error is False
+    assert result.content == "Echo: Bonjour CanaR!"
+    assert result.structured_content == {"echo": "Bonjour CanaR!"}
+
+
+def test_echo_provider_missing_text_argument():
+    provider = EchoToolProvider(provider_id="echo")
+    with pytest.raises(InvalidToolArguments) as exc_info:
+        asyncio.run(provider.call_tool("echo", {}))
+    assert "absent" in str(exc_info.value)
+
+
+def test_echo_provider_invalid_text_type():
+    provider = EchoToolProvider(provider_id="echo")
+    with pytest.raises(InvalidToolArguments) as exc_info:
+        asyncio.run(provider.call_tool("echo", {"text": 12345}))
+    assert "chaîne" in str(exc_info.value)
+
+
+def test_echo_provider_unknown_tool():
+    provider = EchoToolProvider(provider_id="echo")
+    with pytest.raises(ToolNotFound):
+        asyncio.run(provider.call_tool("unknown_tool", {"text": "test"}))
+
+
+def test_registry_registration_and_routing():
+    registry = ToolRegistry()
+    echo_provider = EchoToolProvider(provider_id="echo")
+    registry.register_provider("echo", echo_provider)
+
+    tools = asyncio.run(registry.list_all_tools())
+    assert len(tools) == 1
+    assert tools[0].name == "echo__echo"
+
+    result = asyncio.run(
+        registry.execute_tool(
+            tool_name="echo__echo",
+            arguments={"text": "Test via Registry"},
+            call_id="call_test_123",
+        )
+    )
+    assert result.content == "Echo: Test via Registry"
+    assert result.call_id == "call_test_123"
+
+
+def test_registry_provider_unavailable():
+    registry = ToolRegistry()
+    with pytest.raises(ProviderUnavailable):
+        asyncio.run(registry.execute_tool("inconnu__outil", {"text": "test"}))
+
+
+def test_registry_invalid_provider_id_with_separator():
+    registry = ToolRegistry()
+    echo_provider = EchoToolProvider(provider_id="echo")
+    with pytest.raises(ValueError) as exc_info:
+        registry.register_provider("invalid__id", echo_provider)
+    assert "ne doit pas contenir '__'" in str(exc_info.value)
+
+
+def test_registry_cleanup():
+    registry = ToolRegistry()
+    echo_provider = EchoToolProvider(provider_id="echo")
+    registry.register_provider("echo", echo_provider)
+    asyncio.run(registry.cleanup_all())
+    asyncio.run(registry.cleanup_all())  # Vérifie que close() répétitif ne crash pas

--- a/canar/app/tests/test_tools_domain.py
+++ b/canar/app/tests/test_tools_domain.py
@@ -1,5 +1,7 @@
 import asyncio
+
 import pytest
+
 from canar.app.bot_tools.echo_provider import EchoToolProvider
 from canar.app.bot_tools.errors import (
     InvalidToolArguments,

--- a/canar/app/tests/test_yaml_loader.py
+++ b/canar/app/tests/test_yaml_loader.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 from sqlmodel import Session, SQLModel, create_engine, select
 
-from canar.app.bot_tools.tool_config import ToolProvidersConfig, MCPProviderConfig
+from canar.app.bot_tools.tool_config import MCPProviderConfig, ToolProvidersConfig
 from canar.app.chatbots.chatbot_config import ChatbotConfig
 from canar.app.yaml_loader import load_bot_tools_on_boot, load_chatbot_on_boot
 
@@ -119,9 +119,7 @@ def test_load_bot_tools_on_boot_success(tmp_path: Path):
                     "timeout_seconds": 15,
                 }
             },
-            "local": {
-                "echo": {"description": "Provider echo local"}
-            },
+            "local": {"echo": {"description": "Provider echo local"}},
         }
     }
     filepath = tmp_path / "tools_config.yaml"
@@ -169,9 +167,7 @@ def test_loader_cross_validation_success(mock_db, tmp_path: Path):
                 "name": "Bot Good Tools",
                 "description": "...",
                 "system_prompt": "...",
-                "allowed_tools": [
-                    {"provider": "datagouv", "tools": ["search_datasets"]}
-                ],
+                "allowed_tools": [{"provider": "datagouv", "tools": ["search_datasets"]}],
                 "tool_policy": {
                     "max_iterations": 5,
                     "max_calls_per_turn": 2,

--- a/canar/app/tests/test_yaml_loader.py
+++ b/canar/app/tests/test_yaml_loader.py
@@ -4,8 +4,9 @@ import pytest
 import yaml
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from canar.app.bot_tools.tool_config import ToolProvidersConfig, MCPProviderConfig
 from canar.app.chatbots.chatbot_config import ChatbotConfig
-from canar.app.yaml_loader import load_chatbot_on_boot
+from canar.app.yaml_loader import load_bot_tools_on_boot, load_chatbot_on_boot
 
 # définition des fixtures
 
@@ -42,7 +43,7 @@ def valid_yaml(tmp_path: Path):
 
 @pytest.fixture
 def invalid_yaml(tmp_path: Path):
-    """Génère une YAML avec un bot invalide"""
+    """Génère un YAML avec un bot invalide"""
     data = {
         "chatbots": [
             {"id": "bot_parfait", "name": "Valid", "description": "...", "system_prompt": "..."},
@@ -103,3 +104,91 @@ def test_loader_invalid_yaml_syntax(mock_db, tmp_path: Path):
     with Session(mock_db.engine) as session:
         bots_in_db = session.exec(select(ChatbotConfig)).all()
         assert len(bots_in_db) == 0
+
+
+# --- Nouveaux tests pour le Ticket III-2 ---
+
+
+def test_load_bot_tools_on_boot_success(tmp_path: Path):
+    """Vérifie le chargement de tools_config.yaml avec la structure Option A"""
+    data = {
+        "tool_providers": {
+            "mcp": {
+                "datagouv": {
+                    "url": "https://mcp.data.gouv.fr/mcp",
+                    "timeout_seconds": 15,
+                }
+            },
+            "local": {
+                "echo": {"description": "Provider echo local"}
+            },
+        }
+    }
+    filepath = tmp_path / "tools_config.yaml"
+    with open(filepath, "w", encoding="utf-8") as f:
+        yaml.dump(data, f)
+
+    registry, providers_config = load_bot_tools_on_boot(filepath)
+
+    assert providers_config.has_provider("datagouv") is True
+    assert providers_config.has_provider("echo") is True
+    assert isinstance(providers_config.mcp["datagouv"], MCPProviderConfig)
+
+
+def test_loader_cross_validation_unknown_provider(mock_db, tmp_path: Path):
+    """Vérifie que la validation croisée rejette un chatbot demandant un provider inconnu"""
+    data = {
+        "chatbots": [
+            {
+                "id": "bot_bad_tools",
+                "name": "Bot Bad Tools",
+                "description": "...",
+                "system_prompt": "...",
+                "allowed_tools": ["provider_inexistant"],
+            }
+        ]
+    }
+    filepath = tmp_path / "bot_bad_tools.yaml"
+    with open(filepath, "w", encoding="utf-8") as f:
+        yaml.dump(data, f)
+
+    providers_config = ToolProvidersConfig()  # Aucun provider déclaré
+    load_chatbot_on_boot(filepath, mock_db, providers_config=providers_config)
+
+    with Session(mock_db.engine) as session:
+        bots_in_db = session.exec(select(ChatbotConfig)).all()
+        assert len(bots_in_db) == 0  # Rejeté par la validation croisée
+
+
+def test_loader_cross_validation_success(mock_db, tmp_path: Path):
+    """Vérifie que la validation croisée valide un chatbot référençant un provider existant"""
+    data = {
+        "chatbots": [
+            {
+                "id": "bot_good_tools",
+                "name": "Bot Good Tools",
+                "description": "...",
+                "system_prompt": "...",
+                "allowed_tools": [
+                    {"provider": "datagouv", "tools": ["search_datasets"]}
+                ],
+                "tool_policy": {
+                    "max_iterations": 5,
+                    "max_calls_per_turn": 2,
+                },
+            }
+        ]
+    }
+    filepath = tmp_path / "bot_good_tools.yaml"
+    with open(filepath, "w", encoding="utf-8") as f:
+        yaml.dump(data, f)
+
+    providers_config = ToolProvidersConfig(
+        mcp={"datagouv": MCPProviderConfig(url="https://mcp.data.gouv.fr/mcp")}
+    )
+    load_chatbot_on_boot(filepath, mock_db, providers_config=providers_config)
+
+    with Session(mock_db.engine) as session:
+        bots_in_db = session.exec(select(ChatbotConfig)).all()
+        assert len(bots_in_db) == 1
+        assert bots_in_db[0].id == "bot_good_tools"

--- a/canar/app/yaml_loader.py
+++ b/canar/app/yaml_loader.py
@@ -27,9 +27,7 @@ def load_bot_tools_on_boot(
     path = Path(yaml_path)
 
     if not path.exists():
-        logger.warning(
-            f"[Avertissement] Fichier de configuration des outils introuvable : {path}"
-        )
+        logger.warning(f"[Avertissement] Fichier de configuration des outils introuvable : {path}")
         return registry, providers_config
 
     try:
@@ -49,7 +47,7 @@ def load_bot_tools_on_boot(
         return registry, providers_config
 
     # Instanciation des providers locaux
-    for pid, local_config in providers_config.local.items():
+    for pid, _local_config in providers_config.local.items():
         provider = LocalPythonProvider(provider_id=pid)
         registry.register_provider(pid, provider)
 
@@ -80,9 +78,7 @@ def load_chatbot_on_boot(
         with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
     except Exception as e:
-        logger.exception(
-            f"[Erreur] Une erreur s'est produite lors de la lecture de {path} : {e}"
-        )
+        logger.exception(f"[Erreur] Une erreur s'est produite lors de la lecture de {path} : {e}")
         return
 
     try:
@@ -99,13 +95,13 @@ def load_chatbot_on_boot(
         for bot in config_file.chatbots:
             for pid in bot.get_allowed_provider_ids():
                 if not providers_config.has_provider(pid):
-                    available = (
-                        list(providers_config.mcp.keys())
-                        + list(providers_config.local.keys())
+                    available = list(providers_config.mcp.keys()) + list(
+                        providers_config.local.keys()
                     )
                     logger.error(
-                        f"[Erreur de Configuration] Le chatbot '{bot.id}' fait référence au provider "
-                        f"inconnu '{pid}' dans ses 'allowed_tools'. Providers disponibles : {available}"
+                        f"[Erreur de Configuration] Le chatbot '{bot.id}' fait référence au "
+                        f"provider inconnu '{pid}' dans ses 'allowed_tools'. "
+                        f"Providers disponibles : {available}"
                     )
                     return
 
@@ -117,9 +113,7 @@ def load_chatbot_on_boot(
                     success = bot_db.saveChatbot(session, False)
 
                     if not success:
-                        raise ValueError(
-                            f"Le chatbot '{bot_db.id}' a échoué aux règles métiers."
-                        )
+                        raise ValueError(f"Le chatbot '{bot_db.id}' a échoué aux règles métiers.")
 
             session.commit()
             logger.info(

--- a/canar/app/yaml_loader.py
+++ b/canar/app/yaml_loader.py
@@ -5,40 +5,109 @@ import yaml
 from pydantic import ValidationError
 from sqlmodel import Session
 
+from canar.app.bot_tools.local_provider import LocalPythonProvider
+from canar.app.bot_tools.mcp_provider import MCPProvider
+from canar.app.bot_tools.registry import ToolRegistry
+from canar.app.bot_tools.tool_config import ToolProvidersConfig
 from canar.app.chatbots.chatbot_config import ChatbotConfig
 from canar.app.chatbots.chatbot_config_file import ChatbotConfigFile, ChatbotYAMLConfig
 
 logger = logging.getLogger("YAMLoader")
 
 
-def load_chatbot_on_boot(yaml_path: str | Path, db):
+def load_bot_tools_on_boot(
+    yaml_path: str | Path,
+) -> tuple[ToolRegistry, ToolProvidersConfig]:
     """
-    Lire le fichier YAML et orchestre le chargement des chatbots dans la base de données.
+    Charge le fichier `tools_config.yaml`, instancie les providers locaux et MCP,
+    et les enregistre dans le ToolRegistry.
+    """
+    registry = ToolRegistry()
+    providers_config = ToolProvidersConfig()
+    path = Path(yaml_path)
+
+    if not path.exists():
+        logger.warning(
+            f"[Avertissement] Fichier de configuration des outils introuvable : {path}"
+        )
+        return registry, providers_config
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            raw_data = yaml.safe_load(f) or {}
+
+        # Si les providers sont dans une section `tool_providers` ou à la racine
+        tools_data = raw_data.get("tool_providers", raw_data)
+        providers_config = ToolProvidersConfig.model_validate(tools_data)
+    except ValidationError as e:
+        logger.error(
+            f"[Erreur de Configuration] Le fichier d'outils '{path}' est mal formaté :\n{e}"
+        )
+        return registry, providers_config
+    except Exception as e:
+        logger.error(f"Erreur lors du chargement de {yaml_path} : {e}")
+        return registry, providers_config
+
+    # Instanciation des providers locaux
+    for pid, local_config in providers_config.local.items():
+        provider = LocalPythonProvider(provider_id=pid)
+        registry.register_provider(pid, provider)
+
+    # Instanciation des providers MCP
+    for pid, mcp_config in providers_config.mcp.items():
+        provider = MCPProvider(provider_id=pid, server_url=mcp_config.url)
+        registry.register_provider(pid, provider)
+
+    return registry, providers_config
+
+
+def load_chatbot_on_boot(
+    yaml_path: str | Path, db, providers_config: ToolProvidersConfig | None = None
+):
+    """
+    Lit le fichier `chatbotconfig.yaml`, valide les chatbots et effectue la validation croisée
+    avec les `providers_config` déjà chargés.
     """
     path = Path(yaml_path)
 
     if not path.exists():
-        logger.warning(f"[Avertissement] Fichier de configuration YAML introuvable : {path}")
+        logger.warning(
+            f"[Avertissement] Fichier de configuration des chatbots introuvable : {path}"
+        )
         return
 
     try:
         with open(path, encoding="utf-8") as f:
-            data = yaml.safe_load(f)
-    except yaml.YAMLError as exc:
-        logger.exception(f"[Erreur Fatale] Syntaxe YAML invalide : {exc}")
-        return
+            data = yaml.safe_load(f) or {}
     except Exception as e:
-        logger.exception(f"[Erreur] Une erreur s'est produite : {e}")
+        logger.exception(
+            f"[Erreur] Une erreur s'est produite lors de la lecture de {path} : {e}"
+        )
+        return
 
-    # list_bot = data.get("chatbots", [])
     try:
         config_file = ChatbotConfigFile.model_validate(data)
     except ValidationError as e:
         logger.error(
-            f"[Erreur de Configuration] Le fichier YAML est mal formaté :\n{e}"
-            "\nCanaR a chargé son dernier état fonctionnel."
+            f"[Erreur de Configuration] Le fichier YAML '{path}' est invalide :\n{e}"
+            "\nCanaR a conservé son dernier état fonctionnel."
         )
         return
+
+    # Validation croisée si providers_config est fourni
+    if providers_config is not None:
+        for bot in config_file.chatbots:
+            for pid in bot.get_allowed_provider_ids():
+                if not providers_config.has_provider(pid):
+                    available = (
+                        list(providers_config.mcp.keys())
+                        + list(providers_config.local.keys())
+                    )
+                    logger.error(
+                        f"[Erreur de Configuration] Le chatbot '{bot.id}' fait référence au provider "
+                        f"inconnu '{pid}' dans ses 'allowed_tools'. Providers disponibles : {available}"
+                    )
+                    return
 
     with Session(db.engine) as session:
         try:
@@ -48,16 +117,18 @@ def load_chatbot_on_boot(yaml_path: str | Path, db):
                     success = bot_db.saveChatbot(session, False)
 
                     if not success:
-                        raise ValueError(f"Le chatbot '{bot_db.id}' a echoué aux règles métiers.")
+                        raise ValueError(
+                            f"Le chatbot '{bot_db.id}' a échoué aux règles métiers."
+                        )
 
             session.commit()
             logger.info(
-                f"[Succès] {len(config_file.chatbots)} chatbots chargés "
-                "et validé dans la base de données."
+                f"[Succès] {len(config_file.chatbots)} chatbot(s) chargés "
+                "et validés dans la base de données."
             )
         except Exception as e:
             session.rollback()
             logger.exception(
-                f"[Erreur Fatale] Chargement annulé pour tout les chatbots. Raison : {e}"
+                f"[Erreur Fatale] Chargement annulé pour tous les chatbots. Raison : {e}"
                 "\nCanaR a chargé son dernier état fonctionnel."
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,9 @@ dependencies = [
   "requests>=2.31",
   "psycopg[binary]>=3.1",
   "bcrypt>=4.1",
-  "PyYAML>=6.0"
+  "PyYAML>=6.0",
+  "mcp[cli]==2.0.0b1",
+  "ddgs>=9.14.4"
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ requests>=2.31
 psycopg[binary]>=3.1
 bcrypt>=4.1
 PyYAML>=6.0
+mcp[cli]==2.0.0b1
+ddgs>=9.14.4


### PR DESCRIPTION
## Summary
Refactored and extended CanaR's tool system: added generic domain models (`ToolDefinition`, `ToolResult`), a typed exception hierarchy, `BaseToolProvider` ABC, a mock `EchoToolProvider`, and extended YAML config schemas (`tool_providers` & chatbot `allowed_tools`).
Closes #26
## Changes
- Add agnostic domain models (`ToolDefinition`, `ToolCall`, `ToolResult`) in `bot_tools/models.py`.
- Add typed exception hierarchy (`ToolError`, `ProviderUnavailable`, `ToolNotFound`, etc.) in `bot_tools/errors.py`.
- Add `BaseToolProvider` abstract class and network-free `EchoToolProvider`.
- Extend YAML configuration schemas (`ToolProvidersConfig`, `AllowedToolConfig`, `ToolPolicyConfig`) with Pydantic cross-validation in `config_file.py`.
- Update `yaml_loader.py` to load tool providers on boot.
- Add unit test suite for tool domain and YAML loader (25 passing tests).
## How to test
- [x] `make format`
- [x] `make ci`
## Screenshots (if UI changes)
N/A
## Checklist
- [x] Tests added/updated (or not needed)
- [x] Documentation updated (README/docs)
- [x] No secrets in commits or logs
- [x] Backward compatibility considered (or marked as breaking)